### PR TITLE
Rename client  repository to nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api.video/nodejs-client",
   "version": "2.0.0",
-  "description": "api.video typescript client",
+  "description": "api.video nodejs client",
   "author": "api.video ecosystem team",
   "engines": {
     "node": "^14.16.1"


### PR DESCRIPTION
> The targeted platform isn't `typescript` but `nodejs`.
However it'll works for both `typescript` and standard `es6` projects.
> Created by @lutangar via https://github.com/apivideo/api-client-generator/pull/17