### PR TITLE
Serverless acceptance / axios to fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm run build
 ```
 
 ### Code sample
-
+#### For Production Usage
 ```typescript
 const ApiVideoClient = require('@api.video/nodejs-client');
 // or: import ApiVideoClient from '@api.video/nodejs-client';
@@ -96,6 +96,12 @@ const ApiVideoClient = require('@api.video/nodejs-client');
         console.error(e);
     }
 })();
+
+```
+#### For Development Usage
+For usage of the sandbox api, please change the default baseURI like given in the example:
+```typescript
+const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY", baseUri: "https://sandbox.api.video"  });
 ```
 
 ## Documentation

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -74,10 +74,10 @@ export default class HttpClient {
     });
     const responseData = await fetchRes.json();
     return {
-      accessToken: responseData.data.access_token,
-      refreshToken: responseData.data.refresh_token,
-      tokenType: responseData.data.token_type,
-      expiresIn: responseData.data.expires_in,
+      accessToken: responseData.access_token,
+      refreshToken: responseData.refresh_token,
+      tokenType: responseData.token_type,
+      expiresIn: responseData.expires_in,
     };
   }
 

--- a/src/api/AdvancedAuthenticationApi.ts
+++ b/src/api/AdvancedAuthenticationApi.ts
@@ -67,7 +67,7 @@ export default class AdvancedAuthenticationApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'AccessToken',
             ''
@@ -117,7 +117,7 @@ export default class AdvancedAuthenticationApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'AccessToken',
             ''

--- a/src/api/AnalyticsApi.ts
+++ b/src/api/AnalyticsApi.ts
@@ -126,7 +126,7 @@ export default class AnalyticsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'AnalyticsPlaysResponse',
             ''
@@ -236,7 +236,7 @@ export default class AnalyticsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'AnalyticsPlaysResponse',
             ''

--- a/src/api/CaptionsApi.ts
+++ b/src/api/CaptionsApi.ts
@@ -85,7 +85,7 @@ export default class CaptionsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Caption',
             ''
@@ -129,7 +129,7 @@ Tutorials that use the [captions endpoint](https://api.video/blog/endpoints/capt
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Caption',
             ''
@@ -196,7 +196,7 @@ Tutorials that use the [captions endpoint](https://api.video/blog/endpoints/capt
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Caption',
             ''
@@ -238,7 +238,7 @@ Tutorials that use the [captions endpoint](https://api.video/blog/endpoints/capt
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -302,7 +302,7 @@ Tutorials that use the [captions endpoint](https://api.video/blog/endpoints/capt
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'CaptionsListResponse',
             ''

--- a/src/api/ChaptersApi.ts
+++ b/src/api/ChaptersApi.ts
@@ -84,7 +84,7 @@ export default class ChaptersApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Chapter',
             ''
@@ -126,7 +126,7 @@ export default class ChaptersApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Chapter',
             ''
@@ -168,7 +168,7 @@ export default class ChaptersApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -232,7 +232,7 @@ export default class ChaptersApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'ChaptersListResponse',
             ''

--- a/src/api/LiveStreamsApi.ts
+++ b/src/api/LiveStreamsApi.ts
@@ -11,7 +11,6 @@
 
 import path from 'path';
 import { createReadStream } from 'fs';
-import { URLSearchParams } from 'url';
 import FormData from 'form-data';
 import ObjectSerializer from '../ObjectSerializer';
 import HttpClient, { QueryOptions } from '../HttpClient';
@@ -77,7 +76,7 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStream',
             ''
@@ -111,15 +110,17 @@ export default class LiveStreamsApi {
     return this.httpClient
       .call(localVarPath, queryParams)
       .then(
-        (response) =>
-          ObjectSerializer.deserialize(
+        (response) => {
+          console.log(JSON.stringify(response))
+          return ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStream',
             ''
           ) as LiveStream
+        }
       );
   }
 
@@ -180,7 +181,7 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStream',
             ''
@@ -218,7 +219,7 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -308,12 +309,12 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStreamListResponse',
             ''
           ) as LiveStreamListResponse
-      );
+        );
   }
 
   /**
@@ -365,7 +366,7 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStream',
             ''
@@ -403,11 +404,12 @@ export default class LiveStreamsApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'LiveStream',
             ''
           ) as LiveStream
-      );
+
+        );
   }
 }

--- a/src/api/PlayerThemesApi.ts
+++ b/src/api/PlayerThemesApi.ts
@@ -77,7 +77,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'PlayerTheme',
             ''
@@ -112,7 +112,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'PlayerTheme',
             ''
@@ -174,7 +174,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'PlayerTheme',
             ''
@@ -209,7 +209,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -285,7 +285,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'PlayerThemesListResponse',
             ''
@@ -345,7 +345,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'PlayerTheme',
             ''
@@ -380,7 +380,7 @@ export default class PlayerThemesApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''

--- a/src/api/UploadTokensApi.ts
+++ b/src/api/UploadTokensApi.ts
@@ -68,7 +68,7 @@ export default class UploadTokensApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'UploadToken',
             ''
@@ -106,7 +106,7 @@ export default class UploadTokensApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'UploadToken',
             ''
@@ -144,7 +144,7 @@ export default class UploadTokensApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -216,7 +216,7 @@ export default class UploadTokensApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'TokenListResponse',
             ''

--- a/src/api/VideosApi.ts
+++ b/src/api/VideosApi.ts
@@ -78,7 +78,7 @@ export default class VideosApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -175,7 +175,7 @@ export default class VideosApi {
             ObjectSerializer.deserialize(
               ObjectSerializer.parse(
                 response.body,
-                response.headers['content-type']
+                response.headers.get('content-type') || undefined,
               ),
               'Video',
               ''
@@ -266,7 +266,7 @@ The latter allows you to split a video source into X chunks and send those chunk
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -324,7 +324,7 @@ The latter allows you to split a video source into X chunks and send those chunk
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -440,7 +440,7 @@ The latter allows you to split a video source into X chunks and send those chunk
               ObjectSerializer.deserialize(
                 ObjectSerializer.parse(
                   response.body,
-                  response.headers['content-type']
+                  response.headers.get('content-type') || undefined,
                 ),
                 'Video',
                 ''
@@ -527,7 +527,7 @@ The latter allows you to split a video source into X chunks and send those chunk
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -585,7 +585,7 @@ The latter allows you to split a video source into X chunks and send those chunk
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -625,7 +625,7 @@ The latter allows you to split a video source into X chunks and send those chunk
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -686,7 +686,7 @@ NOTE: If you are updating an array, you must provide the entire array as what yo
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -721,7 +721,7 @@ NOTE: If you are updating an array, you must provide the entire array as what yo
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -851,7 +851,7 @@ NOTE: If you are updating an array, you must provide the entire array as what yo
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'VideosListResponse',
             ''
@@ -917,7 +917,7 @@ Note: There may be a short delay before the new thumbnail is delivered to our CD
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -989,7 +989,7 @@ There may be a short delay for the thumbnail to update.
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Video',
             ''
@@ -1024,7 +1024,7 @@ There may be a short delay for the thumbnail to update.
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'VideoStatus',
             ''

--- a/src/api/WatermarksApi.ts
+++ b/src/api/WatermarksApi.ts
@@ -65,7 +65,7 @@ export default class WatermarksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Watermark',
             ''
@@ -103,7 +103,7 @@ export default class WatermarksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -175,7 +175,7 @@ export default class WatermarksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'WatermarksListResponse',
             ''

--- a/src/api/WebhooksApi.ts
+++ b/src/api/WebhooksApi.ts
@@ -71,7 +71,7 @@ export default class WebhooksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Webhook',
             ''
@@ -106,7 +106,7 @@ export default class WebhooksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'Webhook',
             ''
@@ -141,7 +141,7 @@ export default class WebhooksApi {
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'void',
             ''
@@ -206,7 +206,7 @@ You can filter what the webhook list that the API returns using the parameters d
           ObjectSerializer.deserialize(
             ObjectSerializer.parse(
               response.body,
-              response.headers['content-type']
+              response.headers.get('content-type') || undefined,
             ),
             'WebhooksListResponse',
             ''

--- a/src/model/FetchResponse.ts
+++ b/src/model/FetchResponse.ts
@@ -1,0 +1,3 @@
+export default interface FetchResponse {
+  data: [];
+}


### PR DESCRIPTION
### Why was this needed?
Currently the usage of axios is not compatible with the edge browser. This restricts the usage if this nice library. 
In detail the library could not be used for serverless applications. In my example it was cloudflare workers.

``` Error: Adapter 'http' is not available in the build ```

### What was changed?

1. README.md to also include a small tutorial on how to use the sandbox url for testing
2. HttpClient
2.1 Removed axios package and given imports
2.2 replaced axios calls with native fetch calls
2.3 replaced in every api the method to get the header
2.4 added a response interface for typescript

### What is work in progress?

- [ ] Checking if upload check is working correctly

### Which functions did I test?

- [] Livestreams
- [ ] Videos 
- [ ] Playerthemes
- [ ] Videos 
- [ ] UploadTokens
- [X] AccessToken
- [ ] Watermarks
- [ ] Webhooks

Testing is still work in progress

