### PR TITLE
fix: make postinstall script cross-platform (closes #225)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
   "name": "@api.video/nodejs-client",
   "version": "2.6.4",
   "description": "api.video nodejs API client",
-   "keywords": [
-    "api.video",
-    "api",
-    "video",
-    "client"
-  ],
+  "keywords": ["api.video", "api", "video", "client"],
   "homepage": "https://github.com/apivideo/api.video-nodejs-client#readme",
   "bugs:": "https://github.com/apivideo/api.video-nodejs-client/issues",
   "license": "MIT",
@@ -34,7 +29,7 @@
     "test": "jest",
     "eslint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prettier": "prettier --ignore-path .gitignore --write \"**/*.ts\" && npx eslint src/ test/ --fix",
-    "postinstall": "if [ ! -d \"lib\" ]; then npm run build; fi"
+    "postinstall": "node -e \"const { execSync } = require('child_process'); const { existsSync } = require('fs'); if (!existsSync('lib')) execSync('npm run build', { stdio: 'inherit' });\""
   },
   "dependencies": {
     "axios": "^1.4.0",


### PR DESCRIPTION
This PR resolves the installation issue mentioned in [#225](https://github.com/apivideo/api.video-nodejs-client/issues/225).

The previous postinstall script used a bash-style command that caused errors on Windows systems. This has been replaced with a Node.js-based solution to ensure compatibility across all platforms.

Change:

- Removed the bash-style conditional.
- Added a new Node.js script to check for the lib directory and run the build if necessary.

Let me know if any further changes are needed. Thanks!